### PR TITLE
Fix certain MySQL syntax issues

### DIFF
--- a/app/src/Cops/Core/Entity/BookFile/BookFileRepository.php
+++ b/app/src/Cops/Core/Entity/BookFile/BookFileRepository.php
@@ -85,7 +85,7 @@ class BookFileRepository extends AbstractRepository
     {
         return $this->getBaseSelect()
             ->addSelect('books.path as directory')
-            ->where('book_id IN (:book_id)')
+            ->where('main.book IN (:book_id)')
             ->innerJoin('main', 'books', '', 'books.id = main.book')
             ->setParameter('book_id', $books->getAllIds(), Connection::PARAM_INT_ARRAY)
             ->execute()

--- a/app/src/Cops/Core/Entity/BookRepository.php
+++ b/app/src/Cops/Core/Entity/BookRepository.php
@@ -131,7 +131,7 @@ class BookRepository extends AbstractRepository implements ApplicationAwareInter
     public function countAll()
     {
         return (int) $this->getQueryBuilder()
-            ->select('count()')
+            ->select('count(*)')
             ->from('books', 'main')
             ->execute()
             ->fetchColumn(0);

--- a/app/src/Cops/Core/Entity/TagRepository.php
+++ b/app/src/Cops/Core/Entity/TagRepository.php
@@ -248,7 +248,7 @@ class TagRepository extends AbstractRepository implements TagRepositoryInterface
     public function countAll()
     {
         return (int) $this->getQueryBuilder()
-            ->select('count()')
+            ->select('count(*)')
             ->from('tags', 'main')
             ->execute()
             ->fetchColumn(0);


### PR DESCRIPTION
* MySQL doesn't accept COUNT() - use COUNT(*) instead
* Remove unneeded ALIAS: works with SQLite, but fails with MariaDB 5.5
These changes are compatible with SQLite